### PR TITLE
Add Dockerfile and README steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:18.04
+
+ENV PATH=/usr/local/n64chain/bin:${PATH}
+ENV N64_TOOLCHAIN=/usr/local/n64chain/bin
+ENV ROOT=/etc/n64
+
+WORKDIR /usr/local
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get -y install build-essential git wget libmpfr-dev libmpc-dev libgmp-dev flex bison && \
+    apt-get clean && \
+    git clone https://github.com/CrashOveride95/n64chain.git ./n64chain && \
+    cd n64chain && \
+    ./build-posix64-toolchain.sh && \
+    mkdir -p gcc-source/libgcc/config/mips && \
+    touch gcc-source/libgcc/config/mips/t-mips64 && \
+    cd gcc-build && \
+    make all-target-libgcc CC_FOR_TARGET=$N64_TOOLCHAIN/mips64-elf-gcc CFLAGS_FOR_TARGET="-D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300" && \
+    make install-target-libgcc && \
+    echo "deb [trusted=yes] https://coneyislanddiscopalace.xyz/apt ./" > /etc/apt/sources.list.d/coneyisland.list && \
+    apt update && \
+    apt-get -y install n64sdk && \
+    apt-get -y install spicy && \
+    apt-get -y install makemask && \
+    apt-get -y install root-compatibility-enviroment

--- a/README.md
+++ b/README.md
@@ -7,3 +7,18 @@ It also works fine on WSL.
 
 Instructions for installation will be in [INSTALL.md](https://github.com/CrashOveride95/n64sdkmod/blob/master/INSTALL.md).
 
+## Docker Usage
+
+To build a Docker image from the `Dockerfile` and make it available on your machine:
+
+1. Install Docker, e.g. `brew cask install docker` on macOS using [Homebrew](https://brew.sh)
+2. `docker build --tag n64sdkmod-docker .`
+
+Building the image may take a while, as a GCC cross-compiler needs to be compiled. You may also need to increase the available RAM to 4 GB in Docker's advanced settings to avoid the build process being killed for using up all available container RAM.
+
+To run the container and compile your ROM's source code within the container:
+
+1. `cd /path/to/your/code`
+2. `docker run --volume "$(pwd):/src" n64sdkmod-docker bash -c 'cd /src && make'`
+
+This will copy your source directory into the container, invoke the cross-compiler, and output any build artifacts to your hosts's working directory.


### PR DESCRIPTION
This PR copies the most recent steps from `INSTALL.md` into a `Dockerfile` and adds documentation on how to build and use n64sdkmod as a Docker image.